### PR TITLE
Updated error catching to be php7 friendly

### DIFF
--- a/lib/Resque/Failure.php
+++ b/lib/Resque/Failure.php
@@ -19,11 +19,11 @@ class Resque_Failure
 	 * Create a new failed job on the backend.
 	 *
 	 * @param object $payload        The contents of the job that has just failed.
-	 * @param \Exception $exception  The exception generated when the job failed to run.
+	 * @param \Throwable $exception  The exception generated when the job failed to run.
 	 * @param \Resque_Worker $worker Instance of Resque_Worker that was running this job when it failed.
 	 * @param string $queue          The name of the queue that this job was fetched from.
 	 */
-	public static function create($payload, Exception $exception, Resque_Worker $worker, $queue)
+	public static function create($payload, Throwable $exception, Resque_Worker $worker, $queue)
 	{
 		$backend = self::getBackend();
 		new $backend($payload, $exception, $worker, $queue);

--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -284,7 +284,7 @@ class Resque_Worker
                     'output' => $job->getOutput(),
                     'time' => round(microtime(true) - $startTime, 3) * 1000]
             ], self::LOG_TYPE_INFO);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             $this->log([
                 'message' => $job . ' failed: ' . $e->getMessage(),
                 'data' => [


### PR DESCRIPTION
Fatals are now catchable which is super useful for job queue processing
By catching fatals we can now ensure that jobs are cleanly failed rather
than having a silent fail and not running the tearDown() method